### PR TITLE
Ocaml 4.05.0 fixes

### DIFF
--- a/src/commandDump.ml
+++ b/src/commandDump.ml
@@ -409,7 +409,7 @@ let parsing_pipe json =
       | [], _, _ -> ()
       | read, _, _ -> begin
                       (* 1. get the header *)
-                      let header = String.create 9 in
+                      let header = Bytes.create 9 in
 		      let bytes = Unix.read fd header 0 9 in
 		      (if bytes <> 9
 		      then
@@ -417,7 +417,7 @@ let parsing_pipe json =
 			raise End_of_file));
                       
                       (* 2. check the header *)
-		      let cmd,len,index = _check_header header !previous_index in
+		      let cmd,len,index = _check_header (Bytes.to_string header) !previous_index in
 		      previous_index := index;
 
 		      if cmd = 1 (* the exit code *)
@@ -427,13 +427,13 @@ let parsing_pipe json =
 
 		      (* 3. parse the MRT dump *)
 		      let rec _read_exact fd len_needed =
-		        let tmp = String.create len_needed in
+		        let tmp = Bytes.create len_needed in
 			let bytes = Unix.read fd tmp 0 len_needed in
 			match bytes = len_needed with
 			| true  -> bytes,tmp
 			| false -> let tmp_len = len_needed-bytes in
 			           let b,t = _read_exact fd tmp_len in
-				   bytes+b, tmp^t
+			           bytes+b, tmp
 			           
 		      in
 		      let bytes,tmp = _read_exact fd len in
@@ -442,7 +442,7 @@ let parsing_pipe json =
 		      then
 		        (Printf.printf "ERROR-FATAL: MRT dump - not enough data %d/%d\n" bytes len;
 			raise End_of_file));
-                      _str_parser tmp index peers count_headers;
+                      _str_parser (Bytes.to_string tmp) index peers count_headers;
 
 		      end;
     done

--- a/src/inputs.ml
+++ b/src/inputs.ml
@@ -13,6 +13,7 @@
  *)
 
 
+open Bytes
 open Types
 open Printers
 open MrtTools
@@ -50,10 +51,10 @@ module InputFile = struct
     fd
 
   let retrieve fd len =
-    let tmp = String.create len in
+    let tmp = Bytes.create len in
     match Pervasives.input fd tmp 0 len with
     | 0 -> "",0
-    | n -> (safe_sub tmp 0 n), n (* return the correct number of bytes *)
+    | n -> (safe_sub (Bytes.to_string tmp) 0 n), n (* return the correct number of bytes *)
 
 end;;
 
@@ -68,10 +69,10 @@ module InputGzip = struct
     fd
 
   let retrieve fd len =
-    let tmp = String.create len in
+    let tmp = Bytes.create len in
     match Gzip.input fd tmp 0 len with
     | 0 -> "",0
-    | n -> (safe_sub tmp 0 n),n (* return the correct number of bytes *)
+    | n -> (safe_sub (Bytes.to_string tmp) 0 n),n (* return the correct number of bytes *)
 
 end;;
 
@@ -88,10 +89,10 @@ module InputBz2 = struct
     fd
 
   let retrieve fd len =
-    let tmp = String.create len in
-    match Bz2.read fd tmp 0 len with
+    let tmp = Bytes.create len in
+    match Bz2.read fd (Bytes.to_string tmp) 0 len with
     | 0 -> "",0
-    | n -> (safe_sub tmp 0 n),n (* return the correct number of bytes *)
+    | n -> (safe_sub (Bytes.to_string tmp) 0 n),n (* return the correct number of bytes *)
 
 end;;
 

--- a/src/ml_socket.c
+++ b/src/ml_socket.c
@@ -20,6 +20,7 @@
 /* Convert a 'struct in_addr' to an Ocaml string */
 value inaddr2string(struct in_addr addr_in)
 {
+  CAMLparam0();
   CAMLlocal1(address_binary);
 
   /* Prepare the ocaml string */


### PR DESCRIPTION
This PR fixes two issues that prevent `mabo` from compiling on Ocaml 4.0.5.0. The `caml_frame` error likely affects Ocaml 4.0.4.0 too