### PR TITLE
Lighter Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,11 @@ RUN set -x && \
     apt-get autoclean && apt-get --purge -y autoremove && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Copy the binary and libraries to the distroless image
+FROM gcr.io/distroless/base
+COPY --from=0 /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=0 /lib/x86_64-linux-gnu/libbz2.so.1.0 /lib/x86_64-linux-gnu/libbz2.so.1.0
+COPY --from=0 /mabo/mabo .
+
 # Arguments passed to the container will be passed to the mabo binary
-ENTRYPOINT ["/mabo/mabo"]
+ENTRYPOINT ["/mabo"]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ on a local MRT dump.
 
 ```shell
 $ docker build -t anssi/mabo .
-$ docker run --rm -v latest-bview.gz:/bview.gz anssi/mabo:1.0 prefixes /bview.gz
+$ docker run --rm -v $PWD/latest-bview.gz:/bview.gz anssi/mabo prefixes /bview.gz
 ```
 
 ## Usage


### PR DESCRIPTION
Here are small modifications that produce a smaller Docker image. It reduces it size from ~100MB to ~20MB.